### PR TITLE
Add k8s configurations for API only. Add HealthCheck endpoint.

### DIFF
--- a/cmd/kraken-meta-order-api/main.go
+++ b/cmd/kraken-meta-order-api/main.go
@@ -104,10 +104,26 @@ func deleteMetaOrder() func(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+type healthCheckResponse struct {
+	Status string `json:"status"`
+}
+
+func health() func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		response := healthCheckResponse{
+			Status: "Ok",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(response)
+	}
+}
+
 func handleRequests() {
 	myRouter := mux.NewRouter().StrictSlash(true)
 	myRouter.HandleFunc("/{id}", deleteMetaOrder()).Methods("DELETE")
 	myRouter.HandleFunc("/find", findMetaOrders()).Methods("GET")
+	myRouter.HandleFunc("/health", health()).Methods("GET")
 	myRouter.HandleFunc("/", createMetaOrder()).Methods("POST")
 	myRouter.HandleFunc("/{id}", getMetaOrder()).Methods("GET")
 	log.Fatal(http.ListenAndServe(":8080", myRouter))

--- a/kubernetes/db.yml
+++ b/kubernetes/db.yml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kraken-meta-order-db
+  labels:
+    app: db
+spec:
+  containers:
+    - name: web-ctr
+      image: postgres:13-alpine
+      envFrom:
+        - configMapRef:
+            name: postgres-config
+      ports:
+        - containerPort: 5432

--- a/kubernetes/pod.yml
+++ b/kubernetes/pod.yml
@@ -1,0 +1,13 @@
+# Simple Kubernetes Pod to deploy the app contained in nigelpoulton/getting-started-k8s:1.0
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kraken-meta-order
+  labels:
+    app: web
+spec:
+  containers:
+    - name: web-ctr
+      image: theotherdavid/kraken-meta-order:0.1
+      ports:
+        - containerPort: 8080

--- a/kubernetes/postgres-configmap.yml
+++ b/kubernetes/postgres-configmap.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-config
+  labels:
+    app: postgres
+data:
+  POSTGRES_DB: postgres
+  POSTGRES_USER: postgres
+  POSTGRES_PASSWORD: postgres

--- a/kubernetes/svc-nodeport.yml
+++ b/kubernetes/svc-nodeport.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kraken-meta-order-svc
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+    targetPort: 8080
+    nodePort: 31111
+    protocol: TCP
+  selector:
+    app: web
+    


### PR DESCRIPTION
 DB integration in K8s is not currently working. The Healthcheck is the only piece working when deployed to K8s.
Closes #14 